### PR TITLE
Replace NDA Token Generator with downloadcmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ To download images for ABCD you must have the `abcd_fastqc01.csv` spreadsheet do
 1. At the top-right corner of the page under `logout` is a small icon. Click on it to open the `Selected Filters Workspace`.
 1. Click `Submit to Filter Cart` at the bottom of the workspace.
 1. Wait until the `Filter Cart` window at the top-right no longer says `Updating Filter Cart`. 
-1. Once the Filter Cart is updated, click `Package/Add to Study` in the `Filter Cart` window.
+1. Once the Filter Cart is updated, click `Create Data Package/Add to Study` in the `Filter Cart` window.
 1. Click one of the buttons that says `Create Package`
     - Name each package something like **abcdQC**.
     - Select Only **Include documentation**.
@@ -65,6 +65,30 @@ To download images for ABCD you must have the `abcd_fastqc01.csv` spreadsheet do
 1. Once the `Status` column of your package says `Ready to Download`, click `Start Downloads` at the bottom of the page to begin the download.
     - To track your download's progress at any given point, click the `Refresh Queue` button at the top of the window.  
 1. Once the `Status` column of your file says `Download Complete`, your file is ready.
+
+## Data Packages
+
+### How to Create an NDA Data Package
+
+1. Login to the [NIMH Data Archive](https://nda.nih.gov/).
+1. From the homepage, click the button labeled `GET DATA`.
+1. Select `Data Structures` from left hand menu.
+1. In the `Text Search` window enter `image03` and click `Apply`.
+    - You should see a single result with the heading `Image`.
+1. Click on the `Image` heading.
+1. At the bottom of the page click `Add to Filter Cart`.
+1. Wait until the `Filter Cart` window at the top-right no longer says `Updating Filter Cart`. 
+1. Once the Filter Cart is updated, click `Create Data Package/Add to Study` in the `Filter Cart` window.
+1. In the left hand box titled `Collections by Permission Group` click `Deselect All`.
+1. Search for `fasttrack` using find (e.g. Ctrl-F or Cmd-F)
+1. Select the box next to `[2573] Adolescent Brain Cognitive Development Study (ABCD)`
+1. Scroll to the bottom of the page and click `Create Data Package`
+1. Name the Package something informative and make sure to check the box that says `Include Associated Data Files`
+1. Finally click `Create Data Package`
+
+This fasttrack data package is roughly 71TB in size and may take up to a day to be created. You can check the status of this package by navigating to the `Data Packages` tab within your profile. You should see your newly created package at the top of the table with a status of `Creating Package`. Wait until the status changes to `Ready to Download` before proceeding with next steps.
+
+Make note of the Package ID number (found in the `Data Packages` table). You will need to input this in the run command.
 
 ## Usage
 

--- a/abcd2bids.py
+++ b/abcd2bids.py
@@ -76,7 +76,7 @@ def main():
 
     # Before running any different scripts, validate user's NDA credentials and
     # use them to make NDA token
-    make_nda_token(cli_args)
+    #make_nda_token(cli_args)
 
     # Run all steps sequentially, starting at the one specified by the user
     started = False
@@ -188,12 +188,12 @@ def get_cli_args():
     parser.add_argument(
         "-p",
         "--package_id",
-        required=True
+        required=True,
         help=("ID of the data package that is created via the NDA")
     )
     parser.add_argument(
         "--downloadcmd",
-        default=DOWNLOAD_CMD_PATH
+        default=DOWNLOAD_CMD_PATH,
         help=("Path to downloadcmd executable")
     )
 
@@ -645,7 +645,7 @@ def download_nda_data(cli_args):
                             "--sessions", ','.join(cli_args.sessions),
                             "--modalities", ','.join(cli_args.modalities),
                             "--downloadcmd", cli_args.downloadcmd,
-                            "--package-id", cli_args.package_id)
+                            "--package-id", cli_args.package_id))
 
 
 def unpack_and_setup(args):
@@ -681,12 +681,13 @@ def unpack_and_setup(args):
     for subject, subject_dir in subject_dir_paths.items():
         for session_dir in os.scandir(subject_dir):
             if session_dir.is_dir():
-                for tgz in os.scandir(session_dir.path):
+                tgz_dir = os.path.join(session_dir.path, 'image03')
+                for tgz in os.scandir(tgz_dir):
                     if tgz:
                         # Get session ID from some (arbitrary) .tgz file in
                         # session folder
                         session_name = tgz.name.split("_")[1]
-                        print('Unpacking and setting up tgzs for {} {} located here: {}'.format(subject, session_name, session_dir.path))
+                        print('Unpacking and setting up tgzs for {} {} located here: {}'.format(subject, session_name, tgz_dir))
                         print("Running: ", UNPACK_AND_SETUP, subject, "ses-" + session_name, session_dir.path, args.output, args.temp, args.fsl_dir, args.mre_dir)
 
                         # Unpack/setup the data for this subject/session

--- a/src/aws_downloader.py
+++ b/src/aws_downloader.py
@@ -67,10 +67,17 @@ def generate_parser(parser=None):
         help="List the modalities that should be downloaded. Default: ['anat', 'func', 'dwi']"
 )
     parser.add_argument(
-        '-c',
-        '--config-dir',
+        '--downloadcmd',
+        dest='downloadcmd',
         default=os.path.expanduser('~'),
-        help="Directory containing a .s3cfg-ndar for the NDA. Default: home directory (~)"
+        help="Path to the downloadcmd executable. Default: ~/.local/bin/downloadcmd"
+)
+    parser.add_argument(
+        '-p',
+        '--package-id',
+        dest='package_id',
+        required=True,
+        help="ID of the fasttrack qc data package that is created on the NDA"
 )
 
     return parser
@@ -178,18 +185,16 @@ def main(argv=sys.argv):
                     num_nback += 1
                 if has_dti != 0:
                     num_dti += 1
-                for i in file_paths:
-                    tgz_name = os.path.basename(i)
-                    tgz_path = tgz_dir + '/' + tgz_name
-                    if os.path.exists(tgz_path):
-                        print("{} already exists".format(tgz_path))
-                        continue
-                    else:
-                        aws_cmd = ["s3cmd", "--config", os.path.join(args.config_dir, ".s3cfg-ndar"), "get", i, tgz_dir + "/"]
-                        print("Downloading {} to {}".format(i, tgz_dir))
-                        subprocess.run(aws_cmd)
 
+                # Compile all valid s3 links in a txt file to download using the downloadcmd
+                s3_links_file = os.path.join(download_dir, bids_id, year, 's3_links.txt')
+                with open(s3_links_file, 'w') as f:
+                    f.write('\n'.join(str(s3_link) for s3_link in file_paths))
 
+                # Download s3 links from txt file with downloadcmd
+                subprocess.run([os.path.expanduser(args.downloadcmd), '-dp', args.package_id, '-t', s3_links_file, '-d', tgz_dir])
+
+                
     print("There are %s subject visits" % num_sub_visits)
     print("number of subjects with a T1 : %s" % num_t1)
     print("number of subjects with a T2 : %s" % num_t2)
@@ -198,7 +203,6 @@ def main(argv=sys.argv):
     print("number of subjects with sst  : %s" % num_sst)
     print("number of subjects with nBack: %s" % num_nback)
     print("number of subjects with dti  : %s" % num_dti)
-
 
 
 def add_anat_paths(passed_QC_group, file_paths):

--- a/src/unpack_and_setup.sh
+++ b/src/unpack_and_setup.sh
@@ -64,7 +64,7 @@ mkdir -p ${TempSubjectDir}
 
 # copy all tgz to the scratch space dir
 echo `date`" :COPYING TGZs TO SCRATCH: ${TempSubjectDir}"
-cp ${TGZDIR}/* ${TempSubjectDir}
+cp ${TGZDIR}/image03/* ${TempSubjectDir}
 
 # unpack tgz to ABCD_DCMs directory
 mkdir ${TempSubjectDir}/DCMs


### PR DESCRIPTION
The NDA token generator has been deprecated so we are suggesting that users store their un/pw with keyring, compile a list of s3 links that they wish to download, and download them using the nda-tools utility downloadcmd.