### PR TITLE
Remove BVAL and BVEC injection from DWI data outside GE DV25-28

### DIFF
--- a/src/unpack_and_setup.sh
+++ b/src/unpack_and_setup.sh
@@ -109,35 +109,12 @@ if [ -e ${TempSubjectDir}/DCMs/${SUB}/${VISIT}/dwi ]; then
                 cp `dirname $0`/ABCD_Release_2.0_Diffusion_Tables/GE_bvals_DV25.txt ${orig_bval}
                 echo cp `dirname $0`/ABCD_Release_2.0_Diffusion_Tables/GE_bvecs_DV25.txt ${orig_bvec}
                 cp `dirname $0`/ABCD_Release_2.0_Diffusion_Tables/GE_bvecs_DV25.txt ${orig_bvec}
-            elif dcmdump --search 0018,1020 ${first_dcm} 2>/dev/null | grep -q DV26; then
-                echo "Replacing GE DV26 bvals and bvecs"
+            elif dcmdump --search 0018,1020 ${first_dcm} 2>/dev/null | grep -q -e DV26 -e RX26 -e DV27 -e RX27 -e DV28 -e RX28; then
+                # Don Hagler at UCSD said GE software versions between DV (and RX) 26 and 28 needed to be replaced by the DV26 BVAL/BVEC files
+                echo "Replacing GE bvals and bvecs for software version after DV25 and before DV29"
                 cp `dirname $0`/ABCD_Release_2.0_Diffusion_Tables/GE_bvals_DV26.txt ${orig_bval}
                 cp `dirname $0`/ABCD_Release_2.0_Diffusion_Tables/GE_bvecs_DV26.txt ${orig_bvec}
-            else
-                echo "ERROR setting up DWI: GE software version not recognized"
-                exit
             fi
-        elif [[ `dcmdump --search 0008,0070 ${first_dcm} 2>/dev/null` == *Philips* ]]; then
-            software_version=`dcmdump --search 0018,1020 ${first_dcm} 2>/dev/null | awk '{print $3}'`
-            if [[ ${software_version} == *5.3* ]]; then
-                echo "Replacing Philips s1 bvals and bvecs"
-                cp `dirname $0`/ABCD_Release_2.0_Diffusion_Tables/Philips_bvals_s1.txt ${orig_bval}
-                cp `dirname $0`/ABCD_Release_2.0_Diffusion_Tables/Philips_bvecs_s1.txt ${orig_bvec}
-            elif [[ ${software_version} == *5.4* ]]; then
-                echo "Replacing Philips s2 bvals and bvecs"
-                cp `dirname $0`/ABCD_Release_2.0_Diffusion_Tables/Philips_bvals_s2.txt ${orig_bval}
-                cp `dirname $0`/ABCD_Release_2.0_Diffusion_Tables/Philips_bvecs_s2.txt ${orig_bvec}
-            else
-                echo "ERROR setting up DWI: Philips software version " ${software_version} " not recognized"
-                exit
-            fi
-        elif [[ `dcmdump --search 0008,0070 ${first_dcm} 2>/dev/null` == *SIEMENS* ]]; then
-            echo "Replacing Siemens bvals and bvecs"
-            cp `dirname $0`/ABCD_Release_2.0_Diffusion_Tables/Siemens_bvals.txt ${orig_bval}
-            cp `dirname $0`/ABCD_Release_2.0_Diffusion_Tables/Siemens_bvecs.txt ${orig_bvec}
-        else
-            echo "ERROR setting up DWI: Manufacturer not recognized"
-            exit
         fi
     done
 fi


### PR DESCRIPTION
dcm2niix correctly converts the BVAL and BVEC files except with GE's DV25-DV28 software versions. So this BVAL and BVEC file injection/replacement should be removed from the code. This PR fixes this issue.